### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Option<T>.map` function with unit tests and docs
 - `Option<T>.or` function with unit tests and docs
 - `Option<T>and` function with unit tests and docs
+- `Option<T>.andThen` function with unit tests and docs
 
 ## [0.3.0] - 27/05/2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Result<T, E>.andThen` function with unit tests and docs
 - `Result<T, E>.orElse` function with unit tests and docs
 
+### Updated
+
+- Acknowledge the deprecation notice of @usefultools/monads and update the
+mention to point to @hqoss/monads instead
+
 ## [0.3.0] - 27/05/2020
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Option<T>.or` function with unit tests and docs
 - `Option<T>and` function with unit tests and docs
 - `Option<T>.andThen` function with unit tests and docs
+- `Result<T, E>.map` function with unit tests and docs
 
 ## [0.3.0] - 27/05/2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Option<T>.map` function with unit tests and docs
 - `Option<T>.or` function with unit tests and docs
+- `Option<T>and` function with unit tests and docs
 
 ## [0.3.0] - 27/05/2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Option<T>.andThen` function with unit tests and docs
 - `Result<T, E>.map` function with unit tests and docs
 - `Result<T, E>.andThen` function with unit tests and docs
+- `Result<T, E>.orElse` function with unit tests and docs
 
 ## [0.3.0] - 27/05/2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 07/06/2020
+
 ### Added
 
 - `Option<T>.map` function with unit tests and docs
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Result<T, E>.andThen` function with unit tests and docs
 - `Result<T, E>.orElse` function with unit tests and docs
 - Add in-code docs for Option, Result and utils
+- Add link to doc.deno.land for browsing the documentation generated from the code
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Option<T>.map` function with unit tests and docs
+
 ## [0.3.0] - 27/05/2020
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Option<T>.map` function with unit tests and docs
 - `Option<T>.or` function with unit tests and docs
-- `Option<T>and` function with unit tests and docs
+- `Option<T>.and` function with unit tests and docs
 - `Option<T>.andThen` function with unit tests and docs
 - `Result<T, E>.map` function with unit tests and docs
 - `Result<T, E>.andThen` function with unit tests and docs
 - `Result<T, E>.orElse` function with unit tests and docs
+- Add in-code docs for Option, Result and utils
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Option<T>and` function with unit tests and docs
 - `Option<T>.andThen` function with unit tests and docs
 - `Result<T, E>.map` function with unit tests and docs
+- `Result<T, E>.andThen` function with unit tests and docs
 
 ## [0.3.0] - 27/05/2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Option<T>.map` function with unit tests and docs
+- `Option<T>.or` function with unit tests and docs
 
 ## [0.3.0] - 27/05/2020
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 > Getting `funky` with Deno!
 
 ![CI](https://github.com/ful-stackz/funky/workflows/CI/badge.svg?branch=master)
-[![deno.land status](https://img.shields.io/badge/deno.land%2Fx%2Ffunky-v0.3.0-green?style=flat&logo=deno)](https://deno.land/x/funky@v0.3.0)
+[![deno.land status](https://img.shields.io/badge/deno.land%2Fx%2Ffunky-v0.3.1-green?style=flat&logo=deno)](https://deno.land/x/funky@v0.3.1)
+[![deno.land docs](https://img.shields.io/badge/deno.land-docs-green?style=flat&logo=deno)](https://doc.deno.land/https/deno.land/x/funky@0.3.1/mod.ts)
 
 `funky` brings the beloved `Option<T>`, `Result<T, E>` and other functional 
 utilities into your next **Deno** masterpiece!

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This library is heavily inspired by the awesome
 import { Option, some, none } from "https://deno.land/x/funky/mod.ts";
 import { isUndefined } from "https://deno.land/x/funky/mod.ts";
 
-const getEnvVar = (key: string): Option<User> => {
+const getEnvVar = (key: string): Option<string> => {
   const value = Deno.env.get(key);
   return isUndefined(value) ? none() : some(value);
 };

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 utilities into your next **Deno** masterpiece!
 
 This library is heavily inspired by the awesome
-[@usefultools/monads](https://www.npmjs.com/package/@usefultools/monads) npm package.
+[@hqoss/monads](https://github.com/hqoss/monads).
 
 ## API
 

--- a/lib/option/README.md
+++ b/lib/option/README.md
@@ -5,7 +5,7 @@ This directory contains the `Option<T>` type along with some related utilities.
 - [`Option<T>`](#optiont)
   - [`isSome`](#issome)
   - [`isNone`](#isnone)
-  - [`map`](#map)
+  - [`map()`](#map)
   - [`match()`](#match)
   - [`matchSome()`](#matchsome)
   - [`matchNone()`](#matchnone)

--- a/lib/option/README.md
+++ b/lib/option/README.md
@@ -9,6 +9,7 @@ This directory contains the `Option<T>` type along with some related utilities.
   - [`match()`](#match)
   - [`matchSome()`](#matchsome)
   - [`matchNone()`](#matchnone)
+  - [`or()`](#or)
   - [`unwrap()`](#unwrap)
   - [`unwrapOr()`](#unwrapor)
 - [Utilties](#utilities)
@@ -179,6 +180,28 @@ answer.matchNone(() => {
   console.log("No answer");
 });
 // outputs > "No answer"
+```
+
+### `or()`
+
+> `Option<T>.or<U>(other: Option<U>): Option<T | U>`
+
+If the option is an `OptionNone` returns `@other`. Otherwise keeps the original.
+
+#### Examples
+
+```typescript
+const option = some(42);
+const other = some("default");
+const result = option.or(other);
+console.log(result.unwrap()); // 42
+```
+
+```typescript
+const option = none();
+const other = some("default");
+const result = option.or(other);
+console.log(result.unwrap()); // "default"
 ```
 
 ### `unwrap()`

--- a/lib/option/README.md
+++ b/lib/option/README.md
@@ -5,6 +5,7 @@ This directory contains the `Option<T>` type along with some related utilities.
 - [`Option<T>`](#optiont)
   - [`isSome`](#issome)
   - [`isNone`](#isnone)
+  - [`map`](#map)
   - [`match()`](#match)
   - [`matchSome()`](#matchsome)
   - [`matchNone()`](#matchnone)
@@ -61,6 +62,31 @@ console.log(option.isNone); // false
 ```typescript
 const option = none();
 console.log(option.isNone); // true
+```
+
+### `map()`
+
+> `Option<T>.map(handler: (value: T) => U): Option<U>`
+
+If the option is an `OptionSome` instance invokes the `@handler` function,
+providing the wrapped value as the argument. Returns the result of the
+`@handler` as an `Option`.
+Otherwise, when the option is an `OptionNone` instance returns `OptionNone`.
+
+#### Examples
+
+```typescript
+const option = some("42");
+const mapped = option.map(parseInt);
+console.log(typeof option.unwrap()); // string
+console.log(typeof mapped.unwrap()); // number
+```
+
+```typescript
+const option = none();
+const mapped = option.map(() => "value");
+console.log(option.isNone); // true
+console.log(mapped.isNone); // true
 ```
 
 ### `match()`

--- a/lib/option/README.md
+++ b/lib/option/README.md
@@ -10,6 +10,7 @@ This directory contains the `Option<T>` type along with some related utilities.
   - [`matchSome()`](#matchsome)
   - [`matchNone()`](#matchnone)
   - [`or()`](#or)
+  - [`and()`](#and)
   - [`unwrap()`](#unwrap)
   - [`unwrapOr()`](#unwrapor)
 - [Utilties](#utilities)
@@ -202,6 +203,43 @@ const option = none();
 const other = some("default");
 const result = option.or(other);
 console.log(result.unwrap()); // "default"
+```
+
+### `and()`
+
+> `Option<T>.and<U>(other: Option<U>): Option<U>`
+
+If the option is an `OptionSome` instance returns `@other`. Otherwise returns
+`OptionNone`.
+
+#### Examples
+
+```typescript
+const a = some(42);
+const b = some("more");
+const result = a.and(b);
+console.log(result.isSome); // true
+```
+
+```typescript
+const a = some(42);
+const b = none();
+const result = a.and(b);
+console.log(result.isSome); // false
+```
+
+```typescript
+const a = none();
+const b = none();
+const result = a.and(b);
+console.log(result.isSome); // false
+```
+
+```typescript
+const a = none();
+const b = some(42);
+const result = a.and(b);
+console.log(result.isSome); // false
 ```
 
 ### `unwrap()`

--- a/lib/option/README.md
+++ b/lib/option/README.md
@@ -11,6 +11,7 @@ This directory contains the `Option<T>` type along with some related utilities.
   - [`matchNone()`](#matchnone)
   - [`or()`](#or)
   - [`and()`](#and)
+  - [`andThen()`](#andthen)
   - [`unwrap()`](#unwrap)
   - [`unwrapOr()`](#unwrapor)
 - [Utilties](#utilities)
@@ -240,6 +241,32 @@ const a = none();
 const b = some(42);
 const result = a.and(b);
 console.log(result.isSome); // false
+```
+
+### `andThen()`
+
+> `Option<T>.andThen<U>(handler: (value: T) => Option<U>): Option<U>`
+
+If the option is an `OptionSome` instance invokes the `@handler` function,
+providing the wrapped value as the argument. Returns the result of the
+`@handler`.
+Otherwise, when the option is `OptionNone` returns `OptionNone`.
+
+This function is also known as `flatMap` in other languages.
+
+#### Examples
+
+```typescript
+const userId = 5;
+const findPersonById: Option<User> = (id) => { ... }
+const getFavoriteNumber: Option<number> = (user) => 42;
+console.log(some(userId).andThen(findPersonById).andThen(getFavoriteNumber).unwrap()); // 42
+```
+
+```typescript
+const findPersonById: Option<User> = (id) => { ... }
+const getFavoriteNumber: Option<number> = (user) => 42;
+console.log(none().andThen(findPersonById).andThen(getFavoriteNumber).isNone); // true
 ```
 
 ### `unwrap()`

--- a/lib/option/option.ts
+++ b/lib/option/option.ts
@@ -12,16 +12,70 @@ interface OptionMatch<T, U> {
 
 export interface Option<T> {
   readonly _type: OptionType;
+
+  /**
+   * Indicates whether the option is an `OptionSome` instance.
+   */
   readonly isSome: boolean;
+
+  /**
+   * Indicates whether the option is an `OptionNone` instance.
+   */
   readonly isNone: boolean;
+
+  /**
+   * If the option is an `OptionSome` instance invokes the `@handler` function, providing the wrapped value as the
+   * argument and returns the result as an `Option`. Otherwise, returns an `OptionNone` instance.
+   */
   map<U>(handler: (value: T) => U): Option<U>;
+
+  /**
+   * If the option is an `OptionSome` instance invokes the `@handler.some` function, providing the wrapped value as the
+   * argument and returns the result.
+   *
+   * Otherwise, invokes the `@handler.none` function and returns the result.
+   */
   match<U>(handler: OptionMatch<T, U>): U;
+
+  /**
+   * If the option is an `OptionSome` instance invokes the `@handler` function, providing the wrapped value as the
+   * argument.
+   */
   matchSome(handler: (value: T) => void): void;
+
+  /**
+   * If the option is an `OptionSome` instance invokes the `@handler` function. Otherwise, the `@handler` function is
+   * _not_ invoked.
+   */
   matchNone(handler: () => void): void;
+
+  /**
+   * If the option is an `OptionNone` instance returns the specified `@other` option. Otherwise, returns the original
+   * `OptionSome` instance.
+   */
   or<U>(other: Option<U>): Option<T | U>;
+
+  /**
+   * If the option is an `OptionSome` instance returns the specfied `@other` option. Otherwise, returns an `OptionNone`
+   * instance.
+   */
   and<U>(other: Option<U>): Option<U>;
+
+  /**
+   * If the option is an `OptionSome` instance invokes the `@handler` function, providing the wrapped value as the
+   * argument and returns the result. Otherwise, returns an `OptionNone` instance.
+   */
   andThen<U>(handler: (value: T) => Option<U>): Option<U>;
+
+  /**
+   * If the option is an `OptionSome` instance returns the wrapped value. Otherwise, throws an `Error`.
+   */
   unwrap(): T | never;
+
+  /**
+   * If the option is an `OptionNone` instance returns the specified `@def` value. Otherwise, returns the original
+   * wrapped value.
+   */
   unwrapOr(def: T): T;
 }
 

--- a/lib/option/option.ts
+++ b/lib/option/option.ts
@@ -19,6 +19,7 @@ export interface Option<T> {
   matchSome(handler: (value: T) => void): void;
   matchNone(handler: () => void): void;
   or<U>(other: Option<U>): Option<T | U>;
+  and<U>(other: Option<U>): Option<U>;
   unwrap(): T | never;
   unwrapOr(def: T): T;
 }
@@ -28,6 +29,7 @@ interface OptionSome<T> extends Option<T> {
   matchSome(handler: (value: T) => void): void;
   matchNone(handler: () => void): void;
   or<U>(other: Option<U>): Option<T>;
+  and<U>(other: Option<U>): Option<U>;
   unwrap(): T;
 }
 
@@ -36,6 +38,7 @@ interface OptionNone<T = never> extends Option<T> {
   matchSome(handler: (value: T) => void): void;
   matchNone(handler: () => void): void;
   or<U>(other: Option<U>): Option<U>;
+  and<U>(other: Option<U>): OptionNone<U>;
   unwrap(): never;
 }
 
@@ -76,6 +79,7 @@ export const some = <T>(value: T): OptionSome<T> => {
     },
     matchNone: (): void => {},
     or: (): Option<T> => some(value),
+    and: <U>(other: Option<U>) => other,
     unwrap: (): T => value,
     unwrapOr: (): T => value,
   };
@@ -107,6 +111,7 @@ export const none = <T = never>(): OptionNone<T> => {
       handler();
     },
     or: <U>(other: Option<U>): Option<U> => other,
+    and: <U>(): OptionNone<U> => none<U>(),
     unwrap: (): never => {
       throw new Error(
         "Cannot execute unwrap() on type OptionNone."

--- a/lib/option/option.ts
+++ b/lib/option/option.ts
@@ -18,6 +18,7 @@ export interface Option<T> {
   match<U>(handler: OptionMatch<T, U>): U;
   matchSome(handler: (value: T) => void): void;
   matchNone(handler: () => void): void;
+  or<U>(other: Option<U>): Option<T | U>;
   unwrap(): T | never;
   unwrapOr(def: T): T;
 }
@@ -26,6 +27,7 @@ interface OptionSome<T> extends Option<T> {
   map<U>(handler: (value: T) => U): OptionSome<U>;
   matchSome(handler: (value: T) => void): void;
   matchNone(handler: () => void): void;
+  or<U>(other: Option<U>): Option<T>;
   unwrap(): T;
 }
 
@@ -33,6 +35,7 @@ interface OptionNone<T = never> extends Option<T> {
   map<U>(handler: (value: T) => U): OptionNone<U>;
   matchSome(handler: (value: T) => void): void;
   matchNone(handler: () => void): void;
+  or<U>(other: Option<U>): Option<U>;
   unwrap(): never;
 }
 
@@ -72,6 +75,7 @@ export const some = <T>(value: T): OptionSome<T> => {
       handler(value);
     },
     matchNone: (): void => {},
+    or: (): Option<T> => some(value),
     unwrap: (): T => value,
     unwrapOr: (): T => value,
   };
@@ -102,6 +106,7 @@ export const none = <T = never>(): OptionNone<T> => {
       }
       handler();
     },
+    or: <U>(other: Option<U>): Option<U> => other,
     unwrap: (): never => {
       throw new Error(
         "Cannot execute unwrap() on type OptionNone."

--- a/lib/result/README.md
+++ b/lib/result/README.md
@@ -13,6 +13,7 @@ This directory contains the `Result<T, E>` type along with some related utilitie
   - [`unwrapOr()`](#unwrapor)
   - [`unwrapErr()`](#unwraperr)
   - [`andThen()`](#andthen)
+  - [`orElse()`](#orelse)
 - [Utilties](#utilities)
   - [`isResult()`](#isresult)
   - [`isOk()`](#isok-1)
@@ -246,10 +247,10 @@ console.log(result.unwrapErr()); // "error"
 
 > `Result<T, E>.andThen<U>(handler: (value: T) => Result<U, E>): Result<U, E>`
 
-If the option is an `OptionOk` invokes the `@handler`, providing the wrapped
-value as the argument. Returns the result of the `@handler`.
-Otherwise, when the result is `ResultErr` the `@handler` is not invoked and the
-original `ResultErr` is returned.
+If the result is a `ResultOk` instance invokes the `@handler`, providing the
+wrapped value as the argument. Returns the result of the `@handler`.
+Otherwise, when the result is a `ResultErr` instance the `@handler` is not
+invoked and the original `ResultErr` is returned.
 
 #### Examples
 
@@ -268,6 +269,34 @@ function getFavoriteNumber(user: User): Result<number, Error> { return ok(5); }
 const result = err(new Error("Could not find user"));
 console.log(result.andThen(updateUsername).unwrap()); // throws Error
 console.log(result.andThen(updateUsername).unwrapErr()); // "Could not find user"
+```
+
+### `orElse()`
+
+> `Result<T, E>.orElse<U>(handler: (error: E) => Result<U, E>): Result<U, E>`
+
+If the result is a `ResultErr` instance invokes the `@handler`, providing the
+wrapped error as the argument. Returns the result of the `@handler`.
+Otherwise, when the result is a `ResultOk` instance the `@handler` is not
+invoked and the original `ResultOk` is returned.
+
+#### Examples
+
+```typescript
+function getEnvVar(key: string): Result<string, Error> { ... }
+function setEnvVar(key: string, value: string): Result<string, Error> { ... }
+
+function getOrCreateEnvVar(key: string, defaultValue: string): Result<string, Error> {
+  return getEnvVar(key).orElse((error) => {
+    return error === "not-found"
+      ? setEnvVar(key, defaultValue)
+      : err(error);
+  });
+}
+
+console.log(getEnvVar("THE_DATE")); // ResultErr
+console.log(getOrCreateEnvVar("THE_DATE", Date.now()); // ResultOk
+console.log(getEnvVar("THE_DATE")); // ResultOk
 ```
 
 ## Utilities

--- a/lib/result/README.md
+++ b/lib/result/README.md
@@ -5,6 +5,7 @@ This directory contains the `Result<T, E>` type along with some related utilitie
 - [`Result<T, E>`](#resultte)
   - [`isOk`](#isok)
   - [`isErr`](#iserr)
+  - [`map()`](#map)
   - [`match()`](#match)
   - [`matchOk()`](#matchok)
   - [`matchErr()`](#matcherr)
@@ -30,13 +31,13 @@ further split into `ResultOk<T, E>` and `ResultErr<T, E>`.
 - `ResultOk<T, E>` represents a result which contains a valid value.
 - `ResultErr<T, E>` represents a result which contains an error.
 
-## `isOk`
+### `isOk`
 
 > `Result<T, E>.isOk: boolean`
 
 Indicates whether the result is a `ResultOk` instance.
 
-### Examples
+#### Examples
 
 ```typescript
 const result = ok(42);
@@ -48,13 +49,13 @@ const result = err("error");
 console.log(result.isOk); // false
 ```
 
-## `isErr`
+### `isErr`
 
 > `Result<T, E>.isErr: boolean`
 
 Indicates whether the result is a `ResultErr` instance.
 
-### Examples
+#### Examples
 
 ```typescript
 const result = ok(42);
@@ -66,7 +67,31 @@ const result = err("error");
 console.log(result.isErr); // true
 ```
 
-## `match()`
+### `map()`
+
+> `Result<T, E>.map<U>(handler: (value: T) => U): Result<U, E>`
+
+If the result is a `ResultOk` instance invokes the `@handler`, providing the
+wrapped value as the argument. Returns the result of the `@handler` as a
+`Result`.
+Otherwise, when the result is a `ResultErr`instance returns `ResultErr`.
+
+#### Examples
+
+```typescript
+const result = ok(42);
+const mapped = result.map((value) => `The answer is ${value}`);
+console.log(mapped.unwrap()); // "The answer is 42"
+```
+
+```typescript
+const result = err("Could not find an answer");
+const mapped = result.map((value) => `The answer is ${value}`);
+console.log(mapped.unwrap()); // throws Error
+console.log(mapped.unwrapErr()); // "Could not find an answer"
+```
+
+### `match()`
 
 > `Result<T, E>.match<U>(handler: ResultMatch<T, E, U>): U`
 
@@ -81,7 +106,7 @@ If the result is a `ResultOk` instance then the `@handler.ok` function will be
 invoked, providing the wrapped value as the argument. Otherwise, the `@handler.err`
 function will be invoked, providing the wrapped error as the argument.
 
-### Examples
+#### Examples
 
 ```typescript
 const result = ok(42);
@@ -109,14 +134,14 @@ result.match({
 // outputs > "An error occurred: not found"
 ```
 
-## `matchOk()`
+### `matchOk()`
 
 > `Result<T, E>.matchOk(handler: (value: T) => void): void`
 
 If the result is a `ResultOk` instance then the `@handler` function will be
 invoked, providing the wrapped value as the argument.
 
-### Examples
+#### Examples
 
 ```typescript
 const result = ok(42);
@@ -134,14 +159,14 @@ result.matchOk((value) => {
 // outputs > nothing
 ```
 
-## `matchErr()`
+### `matchErr()`
 
 > `Result<T, E>.matchErr(handler: (error: E) => void): void`
 
 If the result is a `ResultErr` instance then the `@handler` function will be
 invoked, providing the wrapped error as the argument.
 
-### Examples
+#### Examples
 
 ```typescript
 const result = ok(42);
@@ -159,14 +184,14 @@ result.matchErr((error) => {
 // outputs > "An error occurred: not found"
 ```
 
-## `unwrap()`
+### `unwrap()`
 
 > `Result<T, E>.unwrap(): T | never`
 
 If the result is a `ResultOk` instance then the wrapped value will be returned.
 Otherwise, an `Error` is thrown.
 
-### Examples
+#### Examples
 
 ```typescript
 const result = ok(42);
@@ -185,7 +210,7 @@ console.log(result.unwrap()); // throws Error
 If the result is a `ResultOk` instance then the wrapped value will be returned.
 Otherwise, the `@def` value will be returned.
 
-### Examples
+#### Examples
 
 ```typescript
 const result = ok(42);
@@ -197,14 +222,14 @@ const result = err("error");
 console.log(result.unwrapOr(142)); // "142"
 ```
 
-## `unwrapErr()`
+### `unwrapErr()`
 
 > `Result<T, E>.unwrapErr(): E | never`
 
 If the result is a `ResultErr` instance then the wrapped error will be returned.
 Otherwise, an `Error` is thrown.
 
-### Examples
+#### Examples
 
 ```typescript
 const result = ok(42);

--- a/lib/result/README.md
+++ b/lib/result/README.md
@@ -12,6 +12,7 @@ This directory contains the `Result<T, E>` type along with some related utilitie
   - [`unwrap()`](#unwrap)
   - [`unwrapOr()`](#unwrapor)
   - [`unwrapErr()`](#unwraperr)
+  - [`andThen()`](#andthen)
 - [Utilties](#utilities)
   - [`isResult()`](#isresult)
   - [`isOk()`](#isok-1)
@@ -203,7 +204,7 @@ const result = err("error");
 console.log(result.unwrap()); // throws Error
 ```
 
-## `unwrapOr()`
+### `unwrapOr()`
 
 > `Result<T, E>.unwrapOr(def: T): T`
 
@@ -239,6 +240,34 @@ console.log(result.unwrapErr()); // throws Error
 ```typescript
 const result = err("error");
 console.log(result.unwrapErr()); // "error"
+```
+
+### `andThen()`
+
+> `Result<T, E>.andThen<U>(handler: (value: T) => Result<U, E>): Result<U, E>`
+
+If the option is an `OptionOk` invokes the `@handler`, providing the wrapped
+value as the argument. Returns the result of the `@handler`.
+Otherwise, when the result is `ResultErr` the `@handler` is not invoked and the
+original `ResultErr` is returned.
+
+#### Examples
+
+```typescript
+function getUserById(id: number): Result<User, Error> { ... }
+function getFavoriteNumber(user: User): Result<number, Error> { return ok(5); }
+
+const result = getUserById(42);
+console.log(result.andThen(updateUsername).unwrap()); // 5
+```
+
+```typescript
+function getUserById(id: number): Result<User, Error> { ... }
+function getFavoriteNumber(user: User): Result<number, Error> { return ok(5); }
+
+const result = err(new Error("Could not find user"));
+console.log(result.andThen(updateUsername).unwrap()); // throws Error
+console.log(result.andThen(updateUsername).unwrapErr()); // "Could not find user"
 ```
 
 ## Utilities

--- a/lib/result/result.ts
+++ b/lib/result/result.ts
@@ -12,16 +12,69 @@ export interface ResultMatch<T, E, U> {
 
 export interface Result<T, E> {
   readonly _type: ResultType;
+
+  /**
+   * Indicates whether the result is a `ResultOk` instance.
+   */
   readonly isOk: boolean;
+
+  /**
+   * Indicates whether the result is a `ResultErr` instance.
+   */
   readonly isErr: boolean,
+
+  /**
+   * If the result is a `ResultOk` instance invokes the `@handler` function, providing the wrapped value as the
+   * argument and returns the result. Otherwise, returns the original `ResultErr` instance.
+   */
   map<U>(handler: (value: T) => U): Result<U, E>;
+
+  /**
+   * If the result is a `ResultOk` instance invokes the `@handler.ok` function, providing the wrapped value as the
+   * argument and returns the result.
+   *
+   * Otherwise, invokes the `@handler.err` function, providing the wrapped error as the argument and returns the result.
+   */
   match<U>(handler: ResultMatch<T, E, U>): U;
+
+  /**
+   * If the result is a `ResultOk` instance invokes the `@handler` function, providing the wrapped value as the
+   * argument.
+   */
   matchOk(handler: (value: T) => void): void;
+
+  /**
+   * If the result is a `ResultErr` instance invokes the `@handler` function, providing the wrapped error as the
+   * argument.
+   */
   matchErr(handler: (error: E) => void): void;
+
+  /**
+   * If the result is a `ResultOk` instance returns the wrapped value. Otherwise, throws an `Error`.
+   */
   unwrap(): T | never;
+
+  /**
+   * If the result is a `ResultErr` instance returns the specified `@def` value. Otherwise, returns the original
+   * wrapped value.
+   */
   unwrapOr(def: T): T;
+
+  /**
+   * If the result is a `ResultErr` instance returns the wrapped error. Otherwise, throws an `Error`.
+   */
   unwrapErr(): E | never;
+
+  /**
+   * If the result is a `ResultOk` instance invokes the `@handler` function, providing the wrapped value as the
+   * argument and returns the result. Otherwise, returns the original `ResultErr` instance.
+   */
   andThen<U>(handler: (value: T) => Result<U, E>): Result<U, E>;
+
+  /**
+   * If the result is a `ResultErr` instance invokes the `@handler` function, providing the wrapped error as the
+   * argument and returns the result. Otherwise, returns the original `ResultOk` instance.
+   */
   orElse<U>(handler: (error: E) => Result<U, E>): Result<T | U, E>;
 }
 

--- a/lib/result/result.ts
+++ b/lib/result/result.ts
@@ -21,6 +21,7 @@ export interface Result<T, E> {
   unwrap(): T | never;
   unwrapOr(def: T): T;
   unwrapErr(): E | never;
+  andThen<U>(handler: (value: T) => Result<U, E>): Result<U, E>;
 }
 
 interface ResultOk<T, E = never> extends Result<T, E> {
@@ -39,6 +40,7 @@ interface ResultErr<T, E> extends Result<T, E> {
   matchErr(handler: (error: E) => void): void;
   unwrap(): never;
   unwrapErr(): E;
+  andThen<U>(handler: (value: T) => Result<U, E>): ResultErr<never, E>;
 }
 
 export const ok = <T, E = never>(value: T): ResultOk<T, E> => {
@@ -84,6 +86,14 @@ export const ok = <T, E = never>(value: T): ResultOk<T, E> => {
         "Cannot execute unwrapErr() on type ResultOk."
       );
     },
+    andThen: <U>(handler: (value: T) => Result<U, E>): Result<U, E> => {
+      if (!isFunction(handler)) {
+        throw new Error(
+          "ResultErr.andThen(handler) expected @handler to be a function."
+        );
+      }
+      return handler(value);
+    },
   };
 };
 
@@ -117,6 +127,9 @@ export const err = <T, E>(error: E): ResultErr<T, E> => {
     },
     unwrapOr: (def: T): T => def,
     unwrapErr: (): E => error,
+    andThen: <U>(handler: (value: T) => Result<U, E>): ResultErr<never, E> => {
+      return err(error);
+    },
   };
 };
 

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -1,23 +1,42 @@
+/**
+ * Type-safe check whether `@value` is `undefined`.
+ */
 export const isUndefined = (value: any): value is undefined => {
   return typeof value === "undefined";
 };
 
+/**
+ * Type-safe check whether `@value` is `null`.
+ */
 export const isNull = (value: any): value is null => {
   return value === null;
 };
 
+/**
+ * Type-safe check whether `@value` is a `Function`.
+ */
 export const isFunction = (value: any): value is Function => {
   return typeof value === "function";
 };
 
+/**
+ * Type-safe check whether `@value` is a `string`.
+ */
 export const isString = (value: any): value is string => {
   return typeof value === "string";
 };
 
+/**
+ * Type-safe check whether `@value` is a `number`.
+ */
 export const isNumber = (value: any): value is number => {
   return typeof value === "number";
 };
 
+/**
+ * Type-safe check whether `@value` is _missing_. `@value` is considered missing when it is either `null` or
+ * `undefined`.
+ */
 export const isMissing = (value: any): value is null | undefined => {
   return (
     value === null ||
@@ -25,6 +44,9 @@ export const isMissing = (value: any): value is null | undefined => {
   );
 };
 
+/**
+ * Checks whether `@value` is _present_. `@value` is considered present when it is neither `null` nor `undefined`.
+ */
 export const isPresent = (value: any): boolean => {
   return (
     value !== null &&
@@ -36,6 +58,10 @@ export const isArray = (value: any): value is any[] => {
   return Array.isArray(value);
 };
 
+/**
+ * Type-safe check whether the specified `@array` contains only elements of type `T`. The specified `@checkType`
+ * function is invoked on every item in the `@array` to determine whether it is of the expected type.
+ */
 export const isArrayOf = <T>(
   array: any,
   checkType: (value: any) => value is T
@@ -43,10 +69,16 @@ export const isArrayOf = <T>(
   return Array.isArray(array) && array.every(checkType);
 };
 
+/**
+ * Checks whether the specified `@array` is empty. Returns `true` when there are no items in the `@array`.
+ */
 export const isArrayEmpty = (array: any[]): boolean => {
   return array.length === 0;
 };
 
+/**
+ * Type-safe check whether `@value` is of type `Object`.
+ */
 export const isObject = (value: any): value is Object => {
   return (
     value !== null &&
@@ -55,6 +87,10 @@ export const isObject = (value: any): value is Object => {
   );
 };
 
+/**
+ * Checks whether `@value` is one of the specified `@options`. Returns `true` when one of the `@options` is _strictly_
+ * equal to `@value`.
+ */
 export const isOneOf = (value: any, options: any[]): boolean => {
   return options.some((item) => item === value);
 };

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -3,6 +3,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
+  assertThrowsAsync,
 } from "https://deno.land/std/testing/asserts.ts";
 import { Option, some, none } from "../mod.ts";
 
@@ -11,6 +12,13 @@ const verifyOptionSome = <T>(value: T): void => {
 
   assert(option.isSome);
   assertEquals(option.isNone, false);
+
+  (() => {
+    const mappedOption = option.map(() => "mapped");
+    assert(mappedOption.isSome);
+    assertEquals(mappedOption.isNone, false);
+    assertEquals(mappedOption.unwrap(), "mapped");
+  })();
 
   option.match({
     some: (val) => {
@@ -38,6 +46,13 @@ const verifyOptionNone = <T>(): void => {
 
   assert(option.isNone);
   assertEquals(option.isSome, false);
+
+  (() => {
+    const mappedOption = option.map(() => "mapped");
+    assert(mappedOption.isNone);
+    assertEquals(mappedOption.isSome, false);
+    assertThrows(() => mappedOption.unwrap());
+  })();
 
   option.match({
     some: () => {

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -3,7 +3,6 @@ import {
   assertEquals,
   assertThrows,
   fail,
-  assertThrowsAsync,
 } from "https://deno.land/std/testing/asserts.ts";
 import { Option, some, none } from "../mod.ts";
 
@@ -49,6 +48,12 @@ const verifyOptionSome = <T>(value: T): void => {
     assertEquals(result.unwrap(), "next");
   })();
 
+  (() => {
+    const next = () => some("pass");
+    const result = option.andThen(next);
+    assertEquals(result.unwrap(), "pass");
+  })();
+
   assertEquals(option.unwrap(), value);
   assertEquals(option.unwrapOr({} as any), value);
 };
@@ -92,6 +97,12 @@ const verifyOptionNone = <T>(): void => {
   (() => {
     const otherOption = some("next");
     const result = option.and(otherOption);
+    assert(result.isNone);
+  })();
+
+  (() => {
+    const next = (value: any) => some(value);
+    const result = option.andThen(next);
     assert(result.isNone);
   })();
 

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -43,6 +43,12 @@ const verifyOptionSome = <T>(value: T): void => {
     assertEquals(orResult.unwrap(), value);
   })();
 
+  (() => {
+    const otherOption = some("next");
+    const result = option.and(otherOption);
+    assertEquals(result.unwrap(), "next");
+  })();
+
   assertEquals(option.unwrap(), value);
   assertEquals(option.unwrapOr({} as any), value);
 };
@@ -81,6 +87,12 @@ const verifyOptionNone = <T>(): void => {
     const otherOption = some("default");
     const orResult = option.or(otherOption);
     assertEquals(orResult.unwrap(), "default");
+  })();
+
+  (() => {
+    const otherOption = some("next");
+    const result = option.and(otherOption);
+    assert(result.isNone);
   })();
 
   assertThrows(() => option.unwrap());

--- a/test/option.test.ts
+++ b/test/option.test.ts
@@ -37,6 +37,12 @@ const verifyOptionSome = <T>(value: T): void => {
     fail();
   });
 
+  (() => {
+    const otherOption = some("default");
+    const orResult = option.or(otherOption);
+    assertEquals(orResult.unwrap(), value);
+  })();
+
   assertEquals(option.unwrap(), value);
   assertEquals(option.unwrapOr({} as any), value);
 };
@@ -70,6 +76,12 @@ const verifyOptionNone = <T>(): void => {
   option.matchNone(() => {
     assert(true);
   });
+
+  (() => {
+    const otherOption = some("default");
+    const orResult = option.or(otherOption);
+    assertEquals(orResult.unwrap(), "default");
+  })();
 
   assertThrows(() => option.unwrap());
   assertEquals(option.unwrapOr(42 as any), 42);

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -3,6 +3,7 @@ import {
   assertEquals,
   assertThrows,
   fail,
+  assertNotEquals,
 } from "https://deno.land/std/testing/asserts.ts";
 import { ok, err } from "../mod.ts";
 
@@ -47,6 +48,12 @@ const verifyResultOk = (value: any): void => {
     // @ts-ignore
     assertEquals(result.andThen(nextErr).unwrapErr(), "failed");
   })();
+
+  // @ts-ignore
+  result.orElse(() => {
+    fail("ResultOk.orElse(handler) -> @handler should not be invoked");
+    return err({} as any);
+  });
 };
 
 const verifyResultErr = (error: any): void => {
@@ -86,6 +93,13 @@ const verifyResultErr = (error: any): void => {
     const nextErr = () => err("failed");
     assert(result.andThen(nextOk).isErr);
     assert(result.andThen(nextErr).isErr);
+  })();
+
+  (() => {
+    const nextOk = () => ok("success");
+    const nextErr = () => err("failed");
+    assertEquals(result.orElse(nextOk).unwrap(), "success");
+    assertEquals(result.orElse(nextErr).unwrapErr(), "failed");
   })();
 };
 

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -12,6 +12,13 @@ const verifyResultOk = (value: any): void => {
   assert(result.isOk);
   assertEquals(result.isErr, false);
 
+  (() => {
+    const mapped = result.map(() => "mapped");
+    assertEquals(mapped.unwrap(), "mapped");
+    // @ts-ignore
+    assertThrows(() => result.map());
+  })();
+
   result.match({
     ok: (val) => {
       assertEquals(val, value);
@@ -39,6 +46,11 @@ const verifyResultErr = (error: any): void => {
 
   assert(result.isErr);
   assertEquals(result.isOk, false);
+
+  (() => {
+    const mapped = result.map(() => "mapped");
+    assert(mapped.isErr);
+  })();
 
   result.match({
     ok: () => {

--- a/test/result.test.ts
+++ b/test/result.test.ts
@@ -39,6 +39,14 @@ const verifyResultOk = (value: any): void => {
   assertEquals(result.unwrap(), value);
   assertEquals(result.unwrapOr({} as any), value);
   assertThrows(() => result.unwrapErr());
+
+  (() => {
+    const nextOk = () => ok("success");
+    const nextErr = () => err("failed");
+    assertEquals(result.andThen(nextOk).unwrap(), "success");
+    // @ts-ignore
+    assertEquals(result.andThen(nextErr).unwrapErr(), "failed");
+  })();
 };
 
 const verifyResultErr = (error: any): void => {
@@ -72,6 +80,13 @@ const verifyResultErr = (error: any): void => {
   assertThrows(() => result.unwrap());
   assertEquals(result.unwrapOr(42), 42);
   assertEquals(result.unwrapErr(), error);
+
+  (() => {
+    const nextOk = () => ok("success");
+    const nextErr = () => err("failed");
+    assert(result.andThen(nextOk).isErr);
+    assert(result.andThen(nextErr).isErr);
+  })();
 };
 
 Deno.test({


### PR DESCRIPTION
## Added

- `Option.map()`
- `Option.or()`
- `Option.and()`
- `Option.andThen()`
- `Result.map()`
- `Result.andThen()`
- `Result.orElse()`
- Documentation and tests for above functions
- In-code documentation for Option, Result and the utils functions
- Badge with link to the documentation generated from code, available at doc.deno.land

## Updated

- Reference `@hqoss/monads` instead of `@usefultools/monads`

closes #3 