### PR TITLE
Release 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Missing in-code docs for
+  - `some()`
+  - `none()`
+  - `isSome()`
+  - `isNone()`
+  - `ok()`
+  - `err()`
+  - `isOk()`
+  - `isErr()`
+  - `isArray()`
+
 ## [0.3.1] - 07/06/2020
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `isOk()`
   - `isErr()`
   - `isArray()`
+  - `Option`
+  - `Result`
 
 ## [0.3.1] - 07/06/2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 07/06/2020
+
 ### Added
 
 - Missing in-code docs for

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > Getting `funky` with Deno!
 
 ![CI](https://github.com/ful-stackz/funky/workflows/CI/badge.svg?branch=master)
-[![deno.land status](https://img.shields.io/badge/deno.land%2Fx%2Ffunky-v0.3.1-green?style=flat&logo=deno)](https://deno.land/x/funky@v0.3.1)
-[![deno.land docs](https://img.shields.io/badge/deno.land-docs-green?style=flat&logo=deno)](https://doc.deno.land/https/deno.land/x/funky@v0.3.1/mod.ts)
+[![deno.land status](https://img.shields.io/badge/deno.land%2Fx%2Ffunky-v0.3.2-green?style=flat&logo=deno)](https://deno.land/x/funky@v0.3.2)
+[![deno.land docs](https://img.shields.io/badge/deno.land-docs-green?style=flat&logo=deno)](https://doc.deno.land/https/deno.land/x/funky@v0.3.2/mod.ts)
 
 `funky` brings the beloved `Option<T>`, `Result<T, E>` and other functional 
 utilities into your next **Deno** masterpiece!

--- a/lib/option/option.ts
+++ b/lib/option/option.ts
@@ -10,6 +10,10 @@ interface OptionMatch<T, U> {
   none(): U;
 }
 
+/**
+ * Represents a runtime-safe value which is _optional_. An optional value is a value which might or might not be
+ * present. The `Option` type allows you to write safe code around that value, without unexpected runtime exceptions.
+ */
 export interface Option<T> {
   readonly _type: OptionType;
 

--- a/lib/option/option.ts
+++ b/lib/option/option.ts
@@ -99,6 +99,9 @@ interface OptionNone<T = never> extends Option<T> {
   unwrap(): never;
 }
 
+/**
+ * Creates a new `OptionSome<T>` instance, wrapping the specified `@value`.
+ */
 export const some = <T>(value: T): OptionSome<T> => {
   if (isMissing(value)) {
     throw new Error(
@@ -150,6 +153,9 @@ export const some = <T>(value: T): OptionSome<T> => {
   };
 };
 
+/**
+ * Creates a new `OptionNone<T>` instance.
+ */
 export const none = <T = never>(): OptionNone<T> => {
   return {
     _type: OptionType.None,
@@ -187,6 +193,9 @@ export const none = <T = never>(): OptionNone<T> => {
   };
 };
 
+/**
+ * Type-safe check whether `@value` is of type `Option<T>`.
+ */
 export const isOption = <T>(value: Option<T> | any): value is Option<T> => {
   return (
     isObject(value) &&
@@ -194,6 +203,11 @@ export const isOption = <T>(value: Option<T> | any): value is Option<T> => {
   );
 };
 
+/**
+ * Type-safe check whether `@option` is of type `OptionSome<T>`.
+ *
+ * If `@option` is neither `OptionSome` nor `OptionNone` an `Error` is thrown.
+ */
 export const isSome = <T>(option: Option<T>): option is OptionSome<T> => {
   if (!isOption(option)) {
     throw new Error(
@@ -203,6 +217,11 @@ export const isSome = <T>(option: Option<T>): option is OptionSome<T> => {
   return option._type === OptionType.Some;
 };
 
+/**
+ * Type-safe check whether `@option` is of type `OptionNone<T>`.
+ *
+ * If `@option` is neither `OptionSome` nor `OptionNone` an `Error` is thrown.
+ */
 export const isNone = <T>(option: Option<T>): option is OptionNone<T> => {
   if (!isOption(option)) {
     throw new Error(

--- a/lib/result/result.ts
+++ b/lib/result/result.ts
@@ -10,6 +10,11 @@ interface ResultMatch<T, E, U> {
   err(error: E): U;
 }
 
+/**
+ * Represents a runtime-safe result of an operation. The operation might be successful, in which case a `Result`
+ * instance wrapping the produced value of type `T` is returned. Otherwise, when the operation fails a `Result`
+ * instance wrapping the error of type `E` is returned.
+ */
 export interface Result<T, E> {
   readonly _type: ResultType;
 

--- a/lib/result/result.ts
+++ b/lib/result/result.ts
@@ -5,7 +5,7 @@ enum ResultType {
   Err,
 }
 
-export interface ResultMatch<T, E, U> {
+interface ResultMatch<T, E, U> {
   ok(value: T): U;
   err(error: E): U;
 }
@@ -99,6 +99,9 @@ interface ResultErr<T, E> extends Result<T, E> {
   orElse<U>(handler: (error: E) => Result<U, E>): Result<U, E>;
 }
 
+/**
+ * Creates a new `ResultOk<T, E>` instance, wrapping the specified `@value`.
+ */
 export const ok = <T, E = never>(value: T): ResultOk<T, E> => {
   if (isMissing(value)) {
     throw new Error(
@@ -154,6 +157,9 @@ export const ok = <T, E = never>(value: T): ResultOk<T, E> => {
   };
 };
 
+/**
+ * Creates a new `ResultErr<T, E>` instance, wrapping the specified `@error`.
+ */
 export const err = <T, E>(error: E): ResultErr<T, E> => {
   return {
     _type: ResultType.Err,
@@ -198,6 +204,9 @@ export const err = <T, E>(error: E): ResultErr<T, E> => {
   };
 };
 
+/**
+ * Type-safe check whether `@value` is of type `Result<T, E>`.
+ */
 export const isResult = <T, E>(value: Result<T, E> | any): value is Result<T, E> => {
   return (
     isObject(value) &&
@@ -205,6 +214,11 @@ export const isResult = <T, E>(value: Result<T, E> | any): value is Result<T, E>
   );
 };
 
+/**
+ * Type-safe check whether `@result` is of type `ResultOk<T, E>`.
+ *
+ * If `@result` is neither `ResultOk` nor `ResultErr` an `Error` is thrown.
+ */
 export const isOk = <T, E>(result: Result<T, E>): result is ResultOk<T, E> => {
   if (!isResult(result)) {
     throw new Error(
@@ -214,6 +228,11 @@ export const isOk = <T, E>(result: Result<T, E>): result is ResultOk<T, E> => {
   return result._type === ResultType.Ok;
 };
 
+/**
+ * Type-safe check whether `@result` is of type `ResultErr<T, E>`.
+ *
+ * If `@result` is neither `ResultOk` nor `ResultErr` an `Error` is thrown.
+ */
 export const isErr = <T, E>(result: Result<T, E>): result is Result<T, E> => {
   if (!isResult(result)) {
     throw new Error(

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -54,6 +54,9 @@ export const isPresent = (value: any): boolean => {
   );
 };
 
+/**
+ * Type-safe check whether `@value` is an array.
+ */
 export const isArray = (value: any): value is any[] => {
   return Array.isArray(value);
 };


### PR DESCRIPTION
## Added

- Missing in-code docs for
  - `some()`
  - `none()`
  - `isSome()`
  - `isNone()`
  - `ok()`
  - `err()`
  - `isOk()`
  - `isErr()`
  - `isArray()`
  - `Option`
  - `Result`